### PR TITLE
Added `allowIdentityEdit` config option.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+; EditorConfig helps developers define and maintain consistent
+; coding styles between different editors and IDEs.
+
+; For more visit http://editorconfig.org.
+root = true
+
+; Choose between lf or rf on "end_of_line" property
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/config/default.toml
+++ b/config/default.toml
@@ -10,6 +10,7 @@ title="wildduck-www"
     recipients=2000
     forwards=2000
     identities=10
+    allowIdentityEdit=true
     allowJoin=true
     enableSpecial=false # if true the allow creating addresses with special usernames
     # allowed domains for new addresses
@@ -33,7 +34,6 @@ title="wildduck-www"
     postsize="5MB"
     log="dev"
     secret="a cat"
-    baseurl="http://localhost" # link used in emails etc
     secure=false
     listSize=20
 

--- a/routes/account/identities.js
+++ b/routes/account/identities.js
@@ -20,6 +20,7 @@ router.get('/', (req, res, next) => {
             accMenuIdentities: true,
 
             canCreate: identities.length < config.service.identities,
+            canEdit: config.service.allowIdentityEdit,
             identities: identities.map((identity, i) => {
                 identity.index = i + 1;
                 return identity;
@@ -163,6 +164,11 @@ router.post('/create', (req, res) => {
 });
 
 router.get('/edit', (req, res) => {
+    if (!config.service.allowIdentityEdit) {
+        req.flash('danger', 'You\'re not allowed to edit an identity');
+        return res.redirect('/account/identities');
+    }
+
     const updateSchema = Joi.object().keys({
         id: Joi.string()
             .trim()
@@ -210,6 +216,11 @@ router.get('/edit', (req, res) => {
 });
 
 router.post('/edit', (req, res) => {
+    if (!config.service.allowIdentityEdit) {
+        req.flash('danger', 'You\'re not allowed to edit an identity');
+        return res.redirect('/account/identities');
+    }
+
     const createSchema = {
         id: Joi.string()
             .trim()

--- a/views/account/identities.hbs
+++ b/views/account/identities.hbs
@@ -69,7 +69,9 @@
                                     </td>
 
                                     <td class="text-right">
-                                        <a href="/account/identities/edit?id={{id}}" class="btn btn-info btn-xs"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit</a>
+                                        {{#if canEdit}}
+                                            <a href="/account/identities/edit?id={{id}}" class="btn btn-info btn-xs"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit</a>
+                                        {{/if}}
                                         <button class="btn btn-danger btn-xs" data-address="{{address}}" {{#if main}}disabled{{else}}data-identity="{{id}}" data-toggle="modal" data-target="#deleteModal"{{/if}}><span class="glyphicon glyphicon-trash" aria-hidden="true"></span> Delete</button>
                                     </td>
                                 </tr>

--- a/views/account/identities.hbs
+++ b/views/account/identities.hbs
@@ -69,7 +69,7 @@
                                     </td>
 
                                     <td class="text-right">
-                                        {{#if canEdit}}
+                                        {{#if ../canEdit}}
                                             <a href="/account/identities/edit?id={{id}}" class="btn btn-info btn-xs"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Edit</a>
                                         {{/if}}
                                         <button class="btn btn-danger btn-xs" data-address="{{address}}" {{#if main}}disabled{{else}}data-identity="{{id}}" data-toggle="modal" data-target="#deleteModal"{{/if}}><span class="glyphicon glyphicon-trash" aria-hidden="true"></span> Delete</button>


### PR DESCRIPTION
Hi @andris9!
First of all: wildduck and zone-mta are really nice work. 👍  Is there some way to gift you a pack of beer or something similar? 🍻

I missed an option to disallow users to edit their identities so I implemented it.

The new option resides under the key `services.allowIdentityEdit` and is defaulted to `true`.

I also removed the option `www.baseurl` because it wasn't used anywhere. Correct me if I am wrong!

The `.editorconfig` file was added so you can enforce stuff like *tabs-vs-spaces* and *indent-size* across multiple contributors. I didn't want to include it in this PR but I'm stupid and committed the file before the other changes.

Screenshot:

<img width="1187" alt="screen shot 2018-08-26 at 13 01 13" src="https://user-images.githubusercontent.com/5539202/44627555-335c2000-a930-11e8-9c1d-fabe1c616242.png">
