### PR TITLE
enble/disable addresses from other domains in "From" field

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -15,6 +15,8 @@ title="wildduck-www"
     enableSpecial=false # if true the allow creating addresses with special usernames
     # allowed domains for new addresses
     domains=["localhost"]
+    # allow using addresses with other domains in the "From" field
+    allowSendFromOtherDomains=true
 
     generalNotification="" # static notification to show on top of the page
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -3,6 +3,7 @@
 const punycode = require('punycode');
 const he = require('he');
 const Joi = require('joi');
+const config = require('wild-config');
 
 function getAddressesHTML(value, noLinks) {
     let formatSingleLevel = addresses =>
@@ -101,10 +102,24 @@ function normalizeAddress(address, withNames, options) {
     return addr;
 }
 
+function filterIfSendingAllowed({ address }) {
+    const allowSendFromOtherDomains = config.service.allowSendFromOtherDomains;
+    
+    if (allowSendFromOtherDomains) {
+        return true;
+    }
+
+    const domains = config.service.domains;
+    const domain = normalizeDomain(address.substr(address.lastIndexOf('@') + 1));
+
+    return domains.includes(domain);
+}
+
 module.exports = {
     getAddressesHTML,
     normalizeAddress,
     normalizeDomain,
+    filterIfSendingAllowed,
 
     booleanSchema: Joi.boolean().empty('').truthy('Y', 'true', 'yes', 'on', '1', 1).falsy('N', 'false', 'no', 'off', '0', 0)
 };

--- a/routes/webmail.js
+++ b/routes/webmail.js
@@ -155,8 +155,8 @@ router.get('/send', (req, res) => {
                             {
                                 let fromAddress = messageData.from ||
                                     messageData.sender || {
-                                        name: '< >'
-                                    };
+                                    name: '< >'
+                                };
 
                                 let toAddresses = fromAddress.address ? [fromAddress] : [];
                                 let ccAddresses = [];
@@ -204,9 +204,9 @@ router.get('/send', (req, res) => {
                                     '<tr><th>From</th><td>%s</td></tr>',
                                     tools.getAddressesHTML(
                                         messageData.from ||
-                                            messageData.sender || {
-                                                name: '< >'
-                                            }
+                                        messageData.sender || {
+                                            name: '< >'
+                                        }
                                     )
                                 )
                             );
@@ -252,14 +252,16 @@ router.get('/send', (req, res) => {
 
                     // something other than main address might have been the recipient (if this is a reply)
                     fromAddress: hasFromAddress,
-                    addresses: addresses.map(address => {
-                        if (hasFromAddress) {
+                    addresses: addresses
+                        .filter(tools.filterIfSendingAllowed)
+                        .map(address => {
+                            if (hasFromAddress) {
+                                return address;
+                            }
+                            address.name = address.name || req.user.name;
+                            address.selected = address.main;
                             return address;
-                        }
-                        address.name = address.name || req.user.name;
-                        address.selected = address.main;
-                        return address;
-                    }),
+                        }),
 
                     values: {
                         refMailbox,
@@ -342,11 +344,14 @@ router.post('/send', (req, res) => {
                     mailboxes: prepareMailboxList(mailboxes),
 
                     fromAddress,
-                    addresses: addresses.map(address => {
-                        address.name = address.name || req.user.name;
-                        address.selected = result.value.from === address.id;
-                        return address;
-                    }),
+                    addresses: addresses
+                        .filter(tools.filterIfSendingAllowed)
+                        .map(address => {
+                            address.name = address.name || req.user.name;
+                            address.selected = result.value.from === address.id;
+
+                            return address;
+                        }),
 
                     values: result.value,
                     errors,
@@ -638,9 +643,9 @@ router.get('/:mailbox/message/:message', (req, res, next) => {
                 isHtml: true,
                 value: tools.getAddressesHTML(
                     messageData.from ||
-                        messageData.sender || {
-                            name: '< >'
-                        }
+                    messageData.sender || {
+                        name: '< >'
+                    }
                 )
             });
 


### PR DESCRIPTION
This pull request (PR) introduces a new feature that enhances the webmail project's functionality by allowing the disabling of domains not listed in the configuration from being used in the "From" field. 

For example, we have an app for generating disposable email addresses using WildDuck API, so they are displayed in customer's profile but we don't want them to be used for sending. 

Additionally, as the list of approved domains evolves over time, domains may need to be removed from the configuration to restrict their usage effectively.