### PR TITLE
Increase pagination cursor max length from 100 to 1024

### DIFF
--- a/routes/account/security.js
+++ b/routes/account/security.js
@@ -44,8 +44,8 @@ router.get('/', (req, res) => {
 router.get('/events', (req, res, next) => {
     const updateSchema = Joi.object().keys({
         event: Joi.string().empty('').trim().hex().length(24).label('Password ID'),
-        next: Joi.string().max(100).empty(''),
-        previous: Joi.string().max(100).empty(''),
+        next: Joi.string().max(1024).empty(''),
+        previous: Joi.string().max(1024).empty(''),
         page: Joi.number().empty('')
     });
 

--- a/routes/api.js
+++ b/routes/api.js
@@ -212,7 +212,7 @@ router.post('/list', (req, res) => {
     const schema = Joi.object().keys({
         mailbox: Joi.string().hex().lowercase().length(24).allow('starred').required(),
         cursorType: Joi.string().empty('').valid('next', 'previous'),
-        cursorValue: Joi.string().max(100).empty(''),
+        cursorValue: Joi.string().max(1024).empty(''),
         page: Joi.number().empty('').default(1)
     });
 

--- a/routes/webmail.js
+++ b/routes/webmail.js
@@ -1057,8 +1057,8 @@ function renderMailbox(req, res, next) {
         mailbox: Joi.string().hex().length(24).allow('starred', 'search').empty(''),
         unseen: tools.booleanSchema.default(false),
         query: Joi.string().max(255).empty(''),
-        next: Joi.string().max(100).empty(''),
-        previous: Joi.string().max(100).empty(''),
+        next: Joi.string().max(1024).empty(''),
+        previous: Joi.string().max(1024).empty(''),
         page: Joi.number().empty('')
     });
 


### PR DESCRIPTION
## Summary

Since WildDuck v1.45.7 (PR zone-eu/wildduck#818), `mongopagingFindWrapper` wraps pagination cursors with page numbers, increasing cursor length from ~80 to ~118 characters (base64url encoded).

The webmail's Joi validation on `next`/`previous`/`cursorValue` parameters uses `.max(100)`, which rejects these longer cursors and breaks pagination:

```
"next" length must be less than or equal to 100 characters long
```

This PR increases the cursor validation limit to 1024 characters, matching the WildDuck API's own schema in `lib/schemas.js`.

## Changes

- `routes/webmail.js`: `next`/`previous` max 100 → 1024
- `routes/api.js`: `cursorValue` max 100 → 1024
- `routes/account/security.js`: `next`/`previous` max 100 → 1024

## How to reproduce

1. Deploy WildDuck >= v1.45.7 with wildduck-webmail v1.0.2
2. Open a mailbox with enough messages to paginate
3. Click "Older" — fails with cursor length validation error